### PR TITLE
#792: Populate area summary page style fixes

### DIFF
--- a/assets/locales/service.cy.toml
+++ b/assets/locales/service.cy.toml
@@ -64,3 +64,50 @@ one = "Find facts and figures about <a href=\"https://www.scotlandscensus.gov.uk
 [FindFactsAndFiguresNorthernIreland]
 description = "For facts and figures about areas in Northern Ireland, see the Northern Ireland Statistics and Research Agency website."
 one = "For facts and figures about <a href=\"https://www.nisra.gov.uk/statistics/census/2021-census\">areas in Northern Ireland, see the Northern Ireland Statistics and Research Agency website</a>."
+
+
+# Area Summary Page
+[England]
+description = "England"
+one = "England"
+
+[Country]
+description = "Country"
+one = "Country"
+
+[Overview]
+description = "Overview"
+one = "Overview"
+
+[FactsAndFiguresAboutPeople]
+description = "Facts and figures about people living in England"
+one = "Facts and figures about people living in England"
+
+[FindOut]
+description = "Find out"
+one = "Find out"
+
+[HowCrowdedItIs]
+description = "how crowded it is"
+one = "how crowded it is"
+
+
+[HowManyPeopleThinkHealth]
+description = "how many people think their general health is good"
+one = "how many people think their general health is good"
+
+[HowManyHouseholdsEnglishMainLanguage]
+description = "how many households where English is not the main language"
+one = "how many households where English is not the main language"
+
+[HowHouseholdsOwnedMortgageSharedOwnership]
+description = "how many households are owned with a mortgage, loan or shared ownership"
+one = "how many households are owned with a mortgage, loan or shared ownership"
+
+[ViewFactsFiguresNomis]
+description = "View facts and figures on Nomis"
+one = "View facts and figures on Nomis"
+
+[AreasWithinEngland]
+description = "Areas Within England"
+one = "Areas Within England"

--- a/assets/locales/service.en.toml
+++ b/assets/locales/service.en.toml
@@ -29,10 +29,6 @@ one = "Data includes"
 description = "how many people live there"
 one = "how many people live there"
 
-[HowCrowdedItIs]
-description = "how crowded it is"
-one = "how crowded it is"
-
 [PeoplesAverageAge]
 description = "people's average age"
 one = "people's average age"
@@ -83,29 +79,24 @@ description = "Facts and figures about people living in England"
 one = "Facts and figures about people living in England"
 
 [FindOut]
-description = "Find Out"
-one = "Find Out"
+description = "Find out"
+one = "Find out"
 
-[HowManyPeopleLiveHere]
-description = "how many people live here"
-one = "how many people live here"
-
-[HowCrowdedIsIt]
-description = "how crowded is it"
-one = "how crowded is it"
-
+[HowCrowdedItIs]
+description = "how crowded it is"
+one = "how crowded it is"
 
 [HowManyPeopleThinkHealth]
-description = "how many people think their health is good"
-one = "how many people think their health is good"
+description = "how many people think their general health is good"
+one = "how many people think their general health is good"
 
 [HowManyHouseholdsEnglishMainLanguage]
 description = "how many households where English is not the main language"
 one = "how many households where English is not the main language"
 
 [HowHouseholdsOwnedMortgageSharedOwnership]
-description = "how many households are owned without a mortgage, loan or shared ownership"
-one = "how many households are owned without a mortgage, loan or shared ownership"
+description = "how many households are owned with a mortgage, loan or shared ownership"
+one = "how many households are owned with a mortgage, loan or shared ownership"
 
 [ViewFactsFiguresNomis]
 description = "View facts and figures on Nomis"

--- a/assets/templates/area-summary.tmpl
+++ b/assets/templates/area-summary.tmpl
@@ -1,19 +1,19 @@
-<div class="ons-container ons-container--wide">
-    <div class="ons-grid__col ons-col-8@m ons-u-mb-m">
-        {{ if .EnabledBreadcrumbs }}
+<div class="wrapper">
+    <div class="ons-grid ons-js-toc-container">
+        <div class="ons-grid__col ons-col-8@m ons-u-mb-m">
             {{ template "partials/breadcrumb" . }}
-        {{ end }}
-    </div>
-    <div class="ons-grid ons-grid--gutterless ons-u-mt-l ons-u-mb-l">
-        <div class="ons-grid__col ons-col-6@m">
+        </div>
+        <div class="ons-grid__col ons-col-8@m ons-u-mb-s">
             <h1 class="ons-u-fs-xxxl">{{ localise "England" .Language 1 }}</h1>
-            <b>{{ localise "Country" .Language 1 }}: {{ .Code }}</b>
+            <p class="font-size--16"><b>{{ localise "Country" .Language 1 }}:</b> {{ .Code }}</p>
+        </div>
+        <div class="ons-u-mb-s ons-grid__col ons-col-6@m">
             <h2 class="ons-u-fs-xl">{{ localise "Overview" .Language 1 }}</h2>
             <p>{{ localise "FactsAndFiguresAboutPeople" .Language 1 }}</p>
             <p>{{ localise "FindOut" .Language 1 }}:</p>
             <ul>
-                <li>{{ localise "HowManyPeopleLiveHere" .Language 1 }}</li>
-                <li>{{ localise "HowCrowdedIsIt" .Language 1 }}</li>
+                <li>{{ localise "HowManyPeopleLiveThere" .Language 1 }}</li>
+                <li>{{ localise "HowCrowdedItIs" .Language 1 }}</li>
                 <li>{{ localise "PeoplesAverageAge" .Language 1 }}</li>
                 <li>{{ localise "HowManyPeopleThinkHealth" .Language 1 }}</li>
                 <li>{{ localise "HowManyHouseholdsEnglishMainLanguage" .Language 1 }}</li>
@@ -29,18 +29,21 @@
                 </span>
             </a>
         </div>
-    </div>
         {{ if .Relations }}
-            <hr class="ons-u-mt-no" />
-            <div class="ons-grid ons-grid--gutterless ons-u-mt-l ons-u-mb-l">
-                <h2 class="ons-u-fs-xl">{{ localise "AreasWithinEngland" .Language 1 }}</h2>
+            <div class="ons-u-mb-s ons-grid__col ons-col-12@m">
+                <hr class="ons-u-mt-no margin-top" />
+
                 <div class="ons-grid ons-grid--gutterless ons-u-mt-l ons-u-mb-l">
-                    {{ range .Relations }}
-                        <div class="ons-grid__col ons-col-4@m">
-                            <div class="ons-pl-grid-col"><a class="ons-external-link" href="{{ .Href }}" target="_blank">{{ .AreaName }}</a></div>
-                        </div>
-                    {{ end }}
+                    <h2 class="ons-u-fs-xl">{{ localise "AreasWithinEngland" .Language 1 }}</h2>
+                    <div class="ons-grid ons-grid--gutterless ons-u-mt-l ons-u-mb-l">
+                        {{ range .Relations }}
+                            <div class="ons-grid__col ons-col-4@m">
+                                <div class="ons-pl-grid-col"><a class="ons-external-link" href="{{ .Href }}" target="_blank">{{ .AreaName }}</a></div>
+                            </div>
+                        {{ end }}
+                    </div>
                 </div>
             </div>
         {{ end }}
+    </div>
 </div>

--- a/config/config.go
+++ b/config/config.go
@@ -17,7 +17,6 @@ type Config struct {
 	GracefulShutdownTimeout    time.Duration `envconfig:"GRACEFUL_SHUTDOWN_TIMEOUT"`
 	HealthCheckInterval        time.Duration `envconfig:"HEALTHCHECK_INTERVAL"`
 	HealthCheckCriticalTimeout time.Duration `envconfig:"HEALTHCHECK_CRITICAL_TIMEOUT"`
-	EnabledBreadcrumbs         bool          `envconfig:"ENALBED_BREADCRUMBS"`
 }
 
 var cfg *Config

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -57,7 +57,7 @@ func GetAreaViewHandler(w http.ResponseWriter, req *http.Request, ctx context.Co
 		defer wg.Done()
 		areaData, err = c.AreaApi.GetArea(ctx, accessToken, "", collectionID, areaID, acceptedLang)
 		if err != nil {
-			log.Error(ctx, "Fetching Area Data", err)
+			log.Error(ctx, "fetching Area Data", err)
 			return
 		}
 	}()
@@ -66,7 +66,7 @@ func GetAreaViewHandler(w http.ResponseWriter, req *http.Request, ctx context.Co
 		// Create a new local error variable otherwise we will incur a race condition when other goroutines access it
 		relationsData, relationsErr = c.AreaApi.GetRelations(ctx, accessToken, "", collectionID, areaID, acceptedLang)
 		if relationsErr != nil {
-			log.Error(ctx, "Fetching area relations data", relationsErr)
+			log.Error(ctx, "fetching area relations data", relationsErr)
 			return
 		}
 	}()
@@ -74,16 +74,13 @@ func GetAreaViewHandler(w http.ResponseWriter, req *http.Request, ctx context.Co
 		defer wg.Done()
 		ancestorData, ancestorErr = c.AreaApi.GetAncestors(areaID)
 		if ancestorErr != nil {
-			log.Error(ctx, "Fetching ancestor data", err)
+			log.Error(ctx, "fetching ancestor data", err)
 			return
 		}
 	}()
 	wg.Wait()
 	//  View logic
 	basePage := c.Render.NewBasePageModel()
-	ffs := mapper.FeatureFlags{
-		EnabledBreadcrumbs: cfg.EnabledBreadcrumbs,
-	}
-	model := mapper.CreateAreaPage(basePage, areaData, relationsData, ancestorData, ffs)
+	model := mapper.CreateAreaPage(basePage, areaData, relationsData, ancestorData, lang)
 	c.Render.BuildPage(w, model, "area-summary")
 }

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -3,7 +3,7 @@ package mapper
 import (
 	"fmt"
 
-	areas "github.com/ONSdigital/dp-api-clients-go/v2/areas"
+	"github.com/ONSdigital/dp-api-clients-go/v2/areas"
 	coreModel "github.com/ONSdigital/dp-renderer/model"
 )
 
@@ -31,31 +31,26 @@ func CreateStartPage(basePage coreModel.Page) StartPageModel {
 	return model
 }
 
-// FeatureFlags
-type FeatureFlags struct {
-	EnabledBreadcrumbs bool
-}
-
 type AreaModel struct {
 	coreModel.Page
-	Name               string           `json:"name"`
-	Level              string           `json:"level"`
-	Code               string           `json:"code"`
-	Ancestors          []areas.Ancestor `json:"ancestors"`
-	Siblings           []AreaModel      `json:"siblings"`
-	Children           []AreaModel      `json:"children"`
-	Relations          []areas.Relation `json:"relations"`
-	EnabledBreadcrumbs bool
+	Name      string           `json:"name"`
+	Level     string           `json:"level"`
+	Code      string           `json:"code"`
+	Ancestors []areas.Ancestor `json:"ancestors"`
+	Siblings  []AreaModel      `json:"siblings"`
+	Children  []AreaModel      `json:"children"`
+	Relations []areas.Relation `json:"relations"`
 }
 
 // CreateAreaPage maps request area profile data to frontend view
-func CreateAreaPage(basePage coreModel.Page, areaDetails areas.AreaDetails, relations []areas.Relation, ancestors []areas.Ancestor, ffs FeatureFlags) AreaModel {
+func CreateAreaPage(basePage coreModel.Page, areaDetails areas.AreaDetails, relations []areas.Relation, ancestors []areas.Ancestor, lang string) AreaModel {
 	// TODO - load the area data for the requested area once the API has been developed
 	model := AreaModel{
 		Page: basePage,
 	}
-	model.EnabledBreadcrumbs = ffs.EnabledBreadcrumbs
+
 	model.Page.Type = pageType
+	model.Page.Language = lang
 	// Area Details
 	model.Name = areaDetails.Name
 	model.Code = areaDetails.Code
@@ -73,11 +68,14 @@ func CreateAreaPage(basePage coreModel.Page, areaDetails areas.AreaDetails, rela
 		URI:   "/areas",
 	})
 	model.Ancestors = ancestors
-	for _, ancestor := range model.Ancestors {
-		model.Page.Breadcrumb = append(model.Page.Breadcrumb, coreModel.TaxonomyNode{
-			Title: ancestor.Name,
-			URI:   "/areas/" + ancestor.Name,
-		})
+	// Only add children to breadcrumbs if we are not on a country / root area page
+	if len(ancestors) > 1 {
+		for _, ancestor := range ancestors {
+			model.Page.Breadcrumb = append(model.Page.Breadcrumb, coreModel.TaxonomyNode{
+				Title: ancestor.Name,
+				URI:   "/areas/" + ancestor.Name,
+			})
+		}
 	}
 	model.Page.BetaBannerEnabled = true
 	return model

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -44,7 +44,7 @@ func TestUnitMapper(t *testing.T) {
 				Href:     "/v1/area/E12000002",
 			},
 		}
-		ancestors := []areas.Ancestor{areas.Ancestor{
+		ancestors := []areas.Ancestor{{
 			Name:      "England",
 			Level:     "",
 			Code:      "E92000001",
@@ -52,12 +52,10 @@ func TestUnitMapper(t *testing.T) {
 			Siblings:  nil,
 			Children:  nil,
 		}}
-		ffs := FeatureFlags{EnabledBreadcrumbs: true}
-		areaModel := CreateAreaPage(mdl, areaDetails, relations, ancestors, ffs)
-
+		areaModel := CreateAreaPage(mdl, areaDetails, relations, ancestors, "Enalnd")
 		So(areaModel.BetaBannerEnabled, ShouldBeTrue)
 		So(areaModel.Metadata.Title, ShouldEqual, areaModel.Name+" Summary")
-		So(areaModel.Page.Breadcrumb, ShouldHaveLength, 3)
+		So(areaModel.Page.Breadcrumb, ShouldHaveLength, 2)
 		So(areaModel.Page.Breadcrumb[0].Title, ShouldEqual, "Home")
 		So(areaModel.Page.Breadcrumb[0].URI, ShouldEqual, "/")
 		So(areaModel.Page.Breadcrumb[1].Title, ShouldEqual, "Areas")
@@ -74,6 +72,5 @@ func TestUnitMapper(t *testing.T) {
 		So(areaModel.Ancestors[0].Ancestors, ShouldHaveLength, 0)
 		So(areaModel.Ancestors[0].Siblings, ShouldEqual, nil)
 		So(areaModel.Ancestors[0].Children, ShouldEqual, nil)
-		So(areaModel.EnabledBreadcrumbs, ShouldEqual, true)
 	})
 }


### PR DESCRIPTION
### What

Describe what you have changed and why.
These are the fixes required:

<img width="924" alt="Screenshot 2022-02-17 at 14 12 13" src="https://user-images.githubusercontent.com/28711247/154499164-1e15a8f6-5e2a-4144-b768-899d7aae55b4.png">



<img width="793" alt="Screenshot 2022-02-17 at 14 14 42" src="https://user-images.githubusercontent.com/28711247/154499624-ea3e39f1-09c5-43ca-bfa5-81638e5ed99f.png">

Current version after changes:

<img width="994" alt="Screenshot 2022-02-17 at 15 03 28" src="https://user-images.githubusercontent.com/28711247/154509258-6e3b3d48-8fcb-4952-acd9-6bee1add1c52.png">

### How to review

Check the text content matches the mockup

- Check the root breadcrumbs for England is `Home > Areas` and not `Home > Areas > England`.
- Check margins and general alignment 
- Check fonts
- Check that the feature flag env var is removed as we now just fall back to letting the  proxy router service handle flags

Describe the steps required to test the changes.

View the 3 images

### Who can review
anyone with an eye for detail

Describe who worked on the changes, so that other people can review.
myself
