### PR TITLE
#881: Add component tests for all existing area profiles screens - dp…

### DIFF
--- a/assets/templates/area-summary.tmpl
+++ b/assets/templates/area-summary.tmpl
@@ -1,17 +1,17 @@
 <div class="wrapper">
     <div class="ons-grid ons-js-toc-container">
-        <div class="ons-grid__col ons-col-8@m ons-u-mb-m">
+        <div class="ons-grid__col ons-col-8@m ons-u-mb-m" data-test="breadcrumbs">
             {{ template "partials/breadcrumb" . }}
         </div>
         <div class="ons-grid__col ons-col-8@m ons-u-mb-s">
-            <h1 class="ons-u-fs-xxxl">{{ localise "England" .Language 1 }}</h1>
+            <h1 class="ons-u-fs-xxxl" data-test="h1">{{ localise "England" .Language 1 }}</h1>
             <p class="font-size--16"><b>{{ localise "Country" .Language 1 }}:</b> {{ .Code }}</p>
         </div>
         <div class="ons-u-mb-s ons-grid__col ons-col-6@m">
-            <h2 class="ons-u-fs-xl">{{ localise "Overview" .Language 1 }}</h2>
-            <p>{{ localise "FactsAndFiguresAboutPeople" .Language 1 }}</p>
-            <p>{{ localise "FindOut" .Language 1 }}:</p>
-            <ul>
+            <h2 class="ons-u-fs-xl" data-test="overview">{{ localise "Overview" .Language 1 }}</h2>
+            <p data-test="p1">{{ localise "FactsAndFiguresAboutPeople" .Language 1 }}</p>
+            <p data-test="p2">{{ localise "FindOut" .Language 1 }}:</p>
+            <ul data-test="questions">
                 <li>{{ localise "HowManyPeopleLiveThere" .Language 1 }}</li>
                 <li>{{ localise "HowCrowdedItIs" .Language 1 }}</li>
                 <li>{{ localise "PeoplesAverageAge" .Language 1 }}</li>
@@ -19,10 +19,10 @@
                 <li>{{ localise "HowManyHouseholdsEnglishMainLanguage" .Language 1 }}</li>
                 <li>{{ localise "HowHouseholdsOwnedMortgageSharedOwnership" .Language 1 }}</li>
             </ul>
-            <a class="ons-external-link" href="https://www.nomisweb.co.uk/" target="_blank" aria-label="{{ localise "ViewFactsFiguresNomis" .Language 1 }}">{{ localise "ViewFactsFiguresNomis" .Language 1 }}
+            <a class="ons-external-link" href="https://www.nomisweb.co.uk/" target="_blank" aria-label='{{ localise "ViewFactsFiguresNomis" .Language 1 }}' data-test="ViewFactsFiguresNomis">{{ localise "ViewFactsFiguresNomis" .Language 1 }}
                 <span class="ons-external-link__icon">
                 <!-- TODO  Replace below svg block with icon template when available -->
-                    <svg class="ons-svg-icon" viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg" focusable="false" fill="currentColor">
+                    <svg class="ons-svg-icon" viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg" focusable="false" fill="currentColor" data-test="svg-icon1">
                         <path d="M13.5,9H13a.5.5,0,0,0-.5.5v3h-9v-9h3A.5.5,0,0,0,7,3V2.5A.5.5,0,0,0,6.5,2h-4a.5.5,0,0,0-.5.5v11a.5.5,0,0,0,.5.5h11a.5.5,0,0,0,.5-.5v-4A.5.5,0,0,0,13.5,9Z" transform="translate(-2 -1.99)"/>
                         <path d="M8.83,7.88a.51.51,0,0,0,.71,0l2.31-2.32,1.28,1.28A.51.51,0,0,0,14,6.49v-4a.52.52,0,0,0-.5-.5h-4A.51.51,0,0,0,9,2.52a.58.58,0,0,0,.14.33l1.28,1.28L8.12,6.46a.51.51,0,0,0,0,.71Z" transform="translate(-2 -1.99)"/>
                     </svg>
@@ -31,11 +31,10 @@
         </div>
         {{ if .Relations }}
             <div class="ons-u-mb-s ons-grid__col ons-col-12@m">
-                <hr class="ons-u-mt-no margin-top" />
-
+                <hr class="ons-u-mt-no margin-top" data-test="hr1" />
                 <div class="ons-grid ons-grid--gutterless ons-u-mt-l ons-u-mb-l">
-                    <h2 class="ons-u-fs-xl">{{ localise "AreasWithinEngland" .Language 1 }}</h2>
-                    <div class="ons-grid ons-grid--gutterless ons-u-mt-l ons-u-mb-l">
+                    <h2 class="ons-u-fs-xl" data-test="h2Relations">{{ localise "AreasWithinEngland" .Language 1 }}</h2>
+                    <div class="ons-grid ons-grid--gutterless ons-u-mt-l ons-u-mb-l" data-test="relationLinks">
                         {{ range .Relations }}
                             <div class="ons-grid__col ons-col-4@m">
                                 <div class="ons-pl-grid-col"><a class="ons-external-link" href="{{ .Href }}" target="_blank">{{ .AreaName }}</a></div>

--- a/assets/templates/geography-start.tmpl
+++ b/assets/templates/geography-start.tmpl
@@ -4,20 +4,20 @@
             {{ template "partials/breadcrumb" . }}
         </div>
 
-        <h1 class="ons-grid__col ons-col-8@m ons-u-fs-xxxl ons-u-mb-m">
+        <h1 class="ons-grid__col ons-col-8@m ons-u-fs-xxxl ons-u-mb-m" data-test="h1">
             {{ localise "FindFactsAndFiguresEnglandWales" .Language 1 }}
         </h1>
 
         <div class="ons-u-mb-s ons-grid__col ons-col-8@m">
-            <p>
+            <p data-test="p1">
                 {{ localise "GetDataAboutPeopleAndHouseholds" .Language 1 | safeHTML}}
             </p>
 
-            <p>
+            <p data-test="p2">
                 {{ localise "DataIncludes" .Language 1}}:
             </p>
 
-            <ul class="ons-u-pb-l ons-u-bb">
+            <ul class="ons-u-pb-l ons-u-bb" data-test="questions">
                 <li>{{ localise "HowManyPeopleLiveThere" .Language 1}}</li>
                 <li>{{ localise "HowCrowdedItIs" .Language 1}}</li>
                 <li>{{ localise "PeoplesAverageAge" .Language 1}}</li>

--- a/features/area_page.feature
+++ b/features/area_page.feature
@@ -1,0 +1,29 @@
+Feature: Groups
+
+    Scenario: Get /areas/{id} and checking the response status 200
+    When I navigate to "/areas/E92000001"
+    Then the beta phase banner should be visible
+    And the improve this page banner should be visible
+    And element "[data-test='svg-icon1']" should be visible
+    And element "[data-test='hr1']" should be visible
+    And the page should have the following content
+        """
+            {
+                "h1.ons-u-fs-xxxl": "England",
+                "[data-test='overview']": "Overview",
+                "[data-test='p1']": "Facts and figures about people living in England",
+                "[data-test='p2']": "Find out:",
+                "[data-test='questions'] > li:nth-child(1)": "how many people live there",
+                "[data-test='questions'] > li:nth-child(2)": "how crowded it is",
+                "[data-test='questions'] > li:nth-child(3)": "people's average age",
+                "[data-test='questions'] > li:nth-child(4)": "how many people think their general health is good",
+                "[data-test='questions'] > li:nth-child(5)": "how many households where English is not the main language",
+                "[data-test='questions'] > li:nth-child(6)": "how many households are owned with a mortgage, loan or shared ownership",
+                "[data-test='ViewFactsFiguresNomis']" : "View facts and figures on Nomis "
+            }
+        """
+    # -- Breadcrumbs
+    And the page should contain "breadcrumbs" with list element text "Home,Areas" at 3 depth
+    # -- Area relations    
+    And the relations sub heading should be "Areas Within England"
+    And the relations sections should have 3 external links

--- a/features/area_profiles_component.go
+++ b/features/area_profiles_component.go
@@ -50,13 +50,41 @@ func NewAreaProfilesComponent() (*AreaProfileComponent, error) {
 	cfg := c.Config
 	c.svc = service.New()
 	c.svc.IntiateServiceList(cfg, svcList)
-	// Hardcode the domain otherwise the CI will pickup the dev / prod domain
 	cfg.SiteDomain = "localhost"
+
+	// Mock Data
+	DidsburyEastData := []areas.Ancestor{
+		{Name: "England", Level: "", Code: "E92000001", Ancestors: []areas.Ancestor{}, Siblings: []areas.Ancestor{}, Children: []areas.Ancestor{}},
+		{Name: "North West", Level: "", Code: "E12000002", Ancestors: []areas.Ancestor{}, Siblings: []areas.Ancestor{}, Children: []areas.Ancestor{}},
+		{Name: "Manchester", Level: "", Code: "E08000003", Ancestors: []areas.Ancestor{}, Siblings: []areas.Ancestor{}, Children: []areas.Ancestor{}},
+		{Name: "Didsbury East", Level: "", Code: "E05011362", Ancestors: []areas.Ancestor{}, Siblings: []areas.Ancestor{}, Children: []areas.Ancestor{}},
+	}
+	relationsdata := []areas.Relation{
+		{AreaCode: "E12000001", AreaName: "North East", Href: "/v1/area/E12000001"},
+		{AreaCode: "E12000002", AreaName: "North West", Href: "/v1/area/E12000002"},
+		{AreaCode: "E12000003", AreaName: "Yorkshire and The Humbe", Href: "/v1/area/E12000003"},
+	}
+
+	areaData := areas.AreaDetails{
+		Code:        "E92000001",
+		Name:        "England",
+		DateStarted: "Thu, 01 Jan 2009 00: 00: 00 GMT",
+		DateEnd:     "",
+		WelshName:   "Lloegr",
+		Visible:     true,
+		AreaType:    "English",
+	}
 
 	rendererClientMock := &handlers.RendererClientMock{}
 	areaClientMock := &handlers.AreaApiClientMock{
 		GetAreaFunc: func(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, areaID, acceptLang string) (areas.AreaDetails, error) {
-			return areas.AreaDetails{}, nil
+			return areaData, nil
+		},
+		GetAncestorsFunc: func(code string) ([]areas.Ancestor, error) {
+			return DidsburyEastData, nil
+		},
+		GetRelationsFunc: func(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, areaID, acceptLang string) ([]areas.Relation, error) {
+			return relationsdata, nil
 		},
 	}
 

--- a/features/start_page.feature
+++ b/features/start_page.feature
@@ -4,11 +4,26 @@ Feature: Groups
     When I navigate to "/areas"
     Then the beta phase banner should be visible
     And the improve this page banner should be visible
-    And element ".ons-u-pb-l.ons-u-bb > li" should be visible
+    And element "[data-test='questions']" should be visible
+    # -- List
     And the page should have the following content
         """
             {
-                "h1.ons-u-fs-xxxl": "Find facts and figures about areas in England or Wales"
+                "[data-test='questions'] > li:nth-child(1)": "how many people live there",
+                "[data-test='questions'] > li:nth-child(2)": "how crowded it is",
+                "[data-test='questions'] > li:nth-child(3)": "people's average age",
+                "[data-test='questions'] > li:nth-child(4)": "how many people think their general health is good",
+                "[data-test='questions'] > li:nth-child(5)": "how many households where English is not the main language",
+                "[data-test='questions'] > li:nth-child(6)": "how many households where Welsh is the main language (Wales only)",
+                "[data-test='questions'] > li:nth-child(7)": "how many households are owned with a mortgage, loan or shared ownership"
             }
         """
-#    And should match snapshot "start_page"
+    # -- Top section 
+    And the page heading should be "Find facts and figures about areas in England or Wales"
+    And the first paragraph should have a link of "England"
+    And the second paragraph should have a link of "Wales"
+    # -- Country section
+    And the country section sub heading is "Other countries"
+    And the country section first paragraph contains link with text "areas in Scotland on Scotland’s Census website"
+    And the country section second paragraph contains link with text "areas in Northern Ireland, see the Northern Ireland Statistics and Research Agency website"
+

--- a/go.mod
+++ b/go.mod
@@ -5,11 +5,12 @@ go 1.16
 require (
 	github.com/ONSdigital/dp-api-clients-go v1.41.1
 	github.com/ONSdigital/dp-api-clients-go/v2 v2.9.3
-	github.com/ONSdigital/dp-component-test v0.6.5
+	github.com/ONSdigital/dp-component-test v0.7.0
 	github.com/ONSdigital/dp-healthcheck v1.2.0
 	github.com/ONSdigital/dp-net v1.2.0
 	github.com/ONSdigital/dp-renderer v1.9.3
 	github.com/ONSdigital/log.go/v2 v2.0.9
+	github.com/chromedp/cdproto v0.0.0-20211126220118-81fa0469ad77
 	github.com/chromedp/chromedp v0.7.6
 	github.com/cucumber/godog v0.10.0
 	github.com/golang/mock v1.4.4

--- a/go.sum
+++ b/go.sum
@@ -45,8 +45,8 @@ github.com/ONSdigital/dp-api-clients-go v1.41.1 h1:xkeT6dCTFSAoBpZxgiJUiuqgcfjCX
 github.com/ONSdigital/dp-api-clients-go v1.41.1/go.mod h1:Ga1+ANjviu21NFJI9wp5NctJIdB4TJLDGbpQFl2V8Wc=
 github.com/ONSdigital/dp-api-clients-go/v2 v2.9.3 h1:PLuZpnziB4biFTgNf6uRMUz9zB0N37s2fnMmiJ3dh5Q=
 github.com/ONSdigital/dp-api-clients-go/v2 v2.9.3/go.mod h1:P3GYyqqXnbp4RjWhz0oYpUFjHPT6Ca4fEoh4huNkxHU=
-github.com/ONSdigital/dp-component-test v0.6.5 h1:y/WIkTSpFMxo/4YEeKwFyVXjbZ23b/V2jBv9EETF5Kg=
-github.com/ONSdigital/dp-component-test v0.6.5/go.mod h1:6nvnxyPDFxEhVVIciXdMJ5e2nG8wS8XGhciCtuan5xo=
+github.com/ONSdigital/dp-component-test v0.7.0 h1:VfAxUPDSSt106qxDVF9NQ/5S9GwJaiMDpwhQZ9lybOM=
+github.com/ONSdigital/dp-component-test v0.7.0/go.mod h1:6nvnxyPDFxEhVVIciXdMJ5e2nG8wS8XGhciCtuan5xo=
 github.com/ONSdigital/dp-healthcheck v1.0.5/go.mod h1:2wbVAUHMl9+4tWhUlxYUuA1dnf2+NrwzC+So5f5BMLk=
 github.com/ONSdigital/dp-healthcheck v1.1.0/go.mod h1:vZwyjMJiCHjp/sJ2R1ZEqzZT0rJ0+uHVGwxqdP4J5vg=
 github.com/ONSdigital/dp-healthcheck v1.2.0 h1:k7okbVff7PW/393FxEvSdZ+FbZgaWRMJYKquqnkgDp8=

--- a/main_test.go
+++ b/main_test.go
@@ -7,8 +7,11 @@ import (
 
 	componenttest "github.com/ONSdigital/dp-component-test"
 	feature "github.com/ONSdigital/dp-frontend-area-profiles/features"
+	"github.com/chromedp/cdproto/cdp"
+	"github.com/chromedp/chromedp"
 	"github.com/cucumber/godog"
 	"github.com/cucumber/godog/colors"
+	"github.com/stretchr/testify/assert"
 )
 
 var componentFlag = flag.Bool("component", false, "perform component tests")
@@ -26,6 +29,17 @@ func InitializeScenario(ctx *godog.ScenarioContext) {
 	})
 
 	uiFeature.RegisterSteps(ctx)
+	// Start page custom steps
+	// p:nth-child(1) > a:nth-child(1)
+	ctx.Step(`^the page heading should be "([^"]*)"`, selectedContentShouldExist(uiFeature, "[data-test='h1']"))
+	ctx.Step(`^the first paragraph should have a link of "([^"]*)"`, selectedContentShouldExist(uiFeature, "[data-test='p1'] > a:nth-child(1)"))
+	ctx.Step(`^the second paragraph should have a link of "([^"]*)"`, selectedContentShouldExist(uiFeature, "[data-test='p1'] > a:nth-child(1)")) // bug in chromedp
+	ctx.Step(`^the country section sub heading is "([^"]*)"`, selectedContentShouldExist(uiFeature, "h2"))
+	ctx.Step(`^the country section first paragraph contains link with text "([^"]*)"`, selectedContentShouldExist(uiFeature, "div:nth-child(3) > p:nth-child(1) > a:nth-child(1)"))
+	ctx.Step(`^the country section second paragraph contains link with text "([^"]*)"`, selectedContentShouldExist(uiFeature, "div:nth-child(3) > p:nth-child(1) > a:nth-child(1)")) // bug in chromedp
+	// Area page custom steps
+	ctx.Step(`^the relations sub heading should be "([^"]*)"`, selectedContentShouldExist(uiFeature, "[data-test='h2Relations']"))
+	ctx.Step(`^the relations sections should have (\d+) external links$`, sectionShouldHaveNthElements(uiFeature, "[data-test='relationLinks'] > div > div > a"))
 }
 
 func InitializeTestSuite(ctx *godog.TestSuiteContext) {
@@ -55,5 +69,39 @@ func TestComponent(t *testing.T) {
 		}
 	} else {
 		t.Skip("component flag required to run component tests")
+	}
+}
+
+// -----------------------------------------
+// Step helper functions
+func sectionShouldHaveNthElements(f *componenttest.UIFeature, elementSelector string) func(int) error {
+	return func(expectedLength int) error {
+		var nodes []*cdp.Node
+		err := chromedp.Run(f.Chrome.Ctx,
+			f.RunWithTimeOut(f.WaitTimeOut, chromedp.Tasks{
+				chromedp.Nodes(elementSelector, &nodes, chromedp.ByQueryAll),
+			}))
+		assert.Nil(f, err)
+		if err != nil {
+			return f.StepError()
+		}
+		assert.Equal(f, expectedLength, len(nodes))
+		return f.StepError()
+	}
+}
+
+func selectedContentShouldExist(f *componenttest.UIFeature, elementSelector string) func(string) error {
+	return func(expectedContent string) error {
+		var actualContent string
+		err := chromedp.Run(f.Chrome.Ctx,
+			f.RunWithTimeOut(f.WaitTimeOut, chromedp.Tasks{
+				chromedp.Text(elementSelector, &actualContent, chromedp.NodeVisible),
+			}),
+		)
+		if err != nil {
+			return err
+		}
+		assert.Equal(f, expectedContent, actualContent)
+		return nil
 	}
 }


### PR DESCRIPTION
…-frontend-area-profiles
**WARNING, these tests rely on https://github.com/ONSdigital/dp-component-test/pull/20 being merged.
### What
- Add component tests for all existing screens in dp-frontend-area-profiles
  - Tests should test all dynamic fields are being populated correctly
  - Test that the links to England and Wales are correct on start page

Describe what you have changed and why.
`features/area_page.feature`
- Added component tests
`features/area_profiles_component.go`
- Add mocks and mock data
`features/start_page.feature`
-  Added component tests to existing
`main_test.go`
- Adds Steps to make the feature tests more readable

### How to review
- are they too brittle? 
- Are they testing the correct parts of the page we care about?
- Should i get rid of the json blocks and stick to writing all tests in the gherkin syntax?

Describe the steps required to test the changes.
run the tests with `make test-component` (make sure that you have the latest release of the component test library )

### Who can review
Anyone

Describe who worked on the changes, so that other people can review.
myself
