### PR TITLE
Census link added

### DIFF
--- a/assets/templates/area-summary.tmpl
+++ b/assets/templates/area-summary.tmpl
@@ -65,7 +65,7 @@
                                         <a href="#0" class="ons-list__link">Choose and create your own area report</a>
                                     </li> -->
                                     <li class="ons-list__item">
-                                        <a href="https://census.gov.uk/" class="ons-list__link">Census</a>
+                                        <a href="https://www.ons.gov.uk/census" class="ons-list__link">Census</a>
                                     </li>
                                 </ul>
                             </nav>

--- a/assets/templates/geography-start.tmpl
+++ b/assets/templates/geography-start.tmpl
@@ -40,7 +40,7 @@
                                             <a href="#0" class="ons-list__link">Choose and create your own area report</a>
                                         </li> -->
                                         <li class="ons-list__item">
-                                            <a href="https://census.gov.uk/" class="ons-list__link">Census</a>
+                                            <a href="https://www.ons.gov.uk/census" class="ons-list__link">Census</a>
                                         </li>
                                     </ul>
                                 </nav>


### PR DESCRIPTION
### What

Changes the cenus link to https://www.ons.gov.uk/census


### How to review

The census link should navigate to https://www.ons.gov.uk/census.

### Who can review
anyone
Describe who worked on the changes, so that other people can review.
myself